### PR TITLE
add descriptive errors for `var(..)`

### DIFF
--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -38,7 +38,7 @@ pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String> {
     START.call_once(|| {
         dotenv().ok();
     });
-    env::var(key).map_err(Error::EnvVar)
+    env::var(&key).map_err(|err| Error::EnvVar((err, key.as_ref().to_str().unwrap().into())))
 }
 
 /// Returns an iterator of `(key, value)` pairs for all environment variables of the current process.


### PR DESCRIPTION
adds context to error generated by  `dotenv::var("MISSING_VAR")`

before 

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: EnvVar(NotPresent)'
```

to

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: EnvVar(NotPresent): MISSING_VAR'
```