### PR TITLE
fix: support comments in multiline input

### DIFF
--- a/dotenv/tests/test-multiline-comment.rs
+++ b/dotenv/tests/test-multiline-comment.rs
@@ -1,0 +1,26 @@
+mod common;
+use std::env;
+
+use common::tempdir_with_dotenv;
+use dotenvy::dotenv;
+
+#[test]
+fn test_issue_12() {
+    let _f = tempdir_with_dotenv(
+        r#"
+# Start of .env file
+# Comment line with single ' quote
+# Comment line with double " quote
+ # Comment line with double " quote and starts with a space
+TESTKEY=test_val # A '" comment
+# End of .env file
+"#,
+    )
+    .expect("should write test env");
+
+    dotenv().expect("should succeed");
+    assert_eq!(
+        env::var("TESTKEY").expect("test env key not set"),
+        "test_val"
+    );
+}


### PR DESCRIPTION
Support parsing lines that contain comments & quotes.

Previously this input:

```
# Start of .env file
# Comment line with single ' quote
# Comment line with double " quote
 # Comment line with double " quote and starts with a space
TESTKEY=test_val # A '" comment
# End of .env file
```

Would fail the regression test (`test_issue_12`):

```
running 1 test
test test_issue_12 ... FAILED

failures:

---- test_issue_12 stdout ----
thread 'test_issue_12' panicked at 'should succeed: LineParse("# Comment line with single ' quote\n# Comment line with double \" quote\n # Comment line with double \" quote and starts with a space\nTESTKEY=test_val # A '\" comment\n# End of .env file\n", 181)', dotenv/tests/test-multiline-comment.rs:21:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1805:5
   3: core::result::Result<T,E>::expect
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1055:23
   4: test_multiline_comment::test_issue_12
             at /Users/dom/Documents/rust/dotenvy/dotenv/tests/test-multiline-comment.rs:21:5
   5: test_multiline_comment::test_issue_12::{{closure}}
             at /Users/dom/Documents/rust/dotenvy/dotenv/tests/test-multiline-comment.rs:8:1
   6: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

After this commit, the env var is set as expected (`test_val`).

Fixes #12. 

---

* fix: support comments in multiline input (0bcc818)

      Fixes the line parser to respect comments when evaluating quote state.

      Fixes allan2/dotenvy#12.