### PR TITLE
feat: Add optional API to force load, overriding existing environment variables

### DIFF
--- a/dotenv/src/iter.rs
+++ b/dotenv/src/iter.rs
@@ -21,13 +21,25 @@ impl<R: Read> Iter<R> {
         }
     }
 
-    /// Loads all variables found in the `reader` into the environment.
+    /// Loads all variables found in the `reader` into the environment,
+    /// which do not yet exist in the environment.
     pub fn load(self) -> Result<()> {
         for item in self {
             let (key, value) = item?;
             if env::var(&key).is_err() {
                 env::set_var(&key, value);
             }
+        }
+
+        Ok(())
+    }
+
+    /// Loads all variables found in the `reader` into the environment,
+    /// overriding any existing environment variables of the same name.
+    pub fn force_load(self) -> Result<()> {
+        for item in self {
+            let (key, value) = item?;
+            env::set_var(&key, value);
         }
 
         Ok(())

--- a/dotenv/tests/test-dotenv-no-override.rs
+++ b/dotenv/tests/test-dotenv-no-override.rs
@@ -1,0 +1,22 @@
+mod common;
+
+use dotenvy::*;
+use std::{env, error::Error, result::Result};
+
+use crate::common::*;
+
+#[test]
+fn test_dotenv_no_override() -> Result<(), Box<dyn Error>> {
+    let dir = make_test_dotenv()?;
+
+    let iter = dotenv_iter()?;
+
+    env::set_var("TESTKEY", "initial_val");
+
+    iter.load()?;
+    assert_eq!(env::var("TESTKEY")?, "initial_val");
+
+    env::set_current_dir(dir.path().parent().unwrap())?;
+    dir.close()?;
+    Ok(())
+}

--- a/dotenv/tests/test-dotenv-override.rs
+++ b/dotenv/tests/test-dotenv-override.rs
@@ -1,0 +1,22 @@
+mod common;
+
+use dotenvy::*;
+use std::{env, error::Error, result::Result};
+
+use crate::common::*;
+
+#[test]
+fn test_dotenv_override() -> Result<(), Box<dyn Error>> {
+    let dir = make_test_dotenv()?;
+
+    let iter = dotenv_iter()?;
+
+    env::set_var("TESTKEY", "initial_val");
+
+    iter.force_load()?;
+    assert_eq!(env::var("TESTKEY")?, "test_val");
+
+    env::set_current_dir(dir.path().parent().unwrap())?;
+    dir.close()?;
+    Ok(())
+}


### PR DESCRIPTION
I had a use case for `.env` overriding existing environment variables -- others might have a need for it, too.

I am aware that [this feature was not wanted by the maintainer of the original `dotenv`](https://github.com/dotenv-rs/dotenv/issues/12). Please feel free to close the pull request if you believe the alternate overriding API should not be part of this library.

This is my first contribution proposal to a Rust project - please let me know what I need to adjust, if any.

Note: I had not felt comfortable adding an overriding proc macro to `dotenv_codegen_impl` yet. It might be useful to add that, though.