### PR TITLE
Fix comments reggression

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,25 @@
+# Start of .env file
+# Comment line with single ' quote
+# Comment line with double " quote
+ # Comment line, starts with space with double " quote
+
 CODEGEN_TEST_VAR1="hello!"
 CODEGEN_TEST_VAR2="'quotes within quotes'"
+CODEGEN_TEST_VAR3="double quoted with # hash in value"
+CODEGEN_TEST_VAR4='single quoted with # hash in value'
+CODEGEN_TEST_VAR5=not_quoted_with_#_hash_in_value
+CODEGEN_TEST_VAR6=not_quoted_with_comment_beheind # var6 comment
+CODEGEN_TEST_VAR7=not\ quoted\ with\ escaped\ space
+CODEGEN_TEST_VAR8="double quoted with comment beheind" # var7 comment
+ CODEGEN_TEST_VAR9="Variable starts with a whitespace"
+CODEGEN_TEST_VAR10= "Value starts with a whitespace after ="
+CODEGEN_TEST_VAR11 ="Variable ends with a whitespace before ="
+CODEGEN_TEST_MULTILINE1="First Line
+Second Line"
+CODEGEN_TEST_MULTILINE2="# First Line Comment
+Second Line
+#Third Line Comment
+Fourth Line
+" # multline2 comment
+
+# End of .env file

--- a/dotenv/examples/list_variables.rs
+++ b/dotenv/examples/list_variables.rs
@@ -1,0 +1,10 @@
+use dotenvy::{dotenv_iter, Error};
+
+fn main() -> Result<(), Error> {
+    dotenvy::dotenv()?;
+    for item in dotenv_iter()? {
+        let (key, val) = item?;
+        println!("{key}={val}");
+    }
+    Ok(())
+}

--- a/dotenv/tests/test-multiline-comment.rs
+++ b/dotenv/tests/test-multiline-comment.rs
@@ -12,7 +12,16 @@ fn test_issue_12() {
 # Comment line with single ' quote
 # Comment line with double " quote
  # Comment line with double " quote and starts with a space
-TESTKEY=test_val # A '" comment
+TESTKEY1=test_val # 1 '" comment
+TESTKEY2=test_val_with_#_hash # 2 '" comment
+TESTKEY3="test_val quoted with # hash" # 3 '" comment
+TESTKEY4="Line 1
+# Line 2
+Line 3" # 4 Multiline "' comment
+TESTKEY5="Line 4
+# Line 5
+Line 6
+" # 5 Multiline "' comment
 # End of .env file
 "#,
     )
@@ -20,7 +29,29 @@ TESTKEY=test_val # A '" comment
 
     dotenv().expect("should succeed");
     assert_eq!(
-        env::var("TESTKEY").expect("test env key not set"),
+        env::var("TESTKEY1").expect("testkey1 env key not set"),
         "test_val"
     );
+    assert_eq!(
+        env::var("TESTKEY2").expect("testkey2 env key not set"),
+        "test_val_with_#_hash"
+    );
+    assert_eq!(
+        env::var("TESTKEY3").expect("testkey3 env key not set"),
+        "test_val quoted with # hash"
+    );
+    assert_eq!(
+        env::var("TESTKEY4").expect("testkey4 env key not set"),
+        r#"Line 1
+# Line 2
+Line 3"#
+    );
+    assert_eq!(
+        env::var("TESTKEY5").expect("testkey5 env key not set"),
+        r#"Line 4
+# Line 5
+Line 6
+"#
+    );
+
 }


### PR DESCRIPTION
This PR fixes #12

Added a WhiteSpace ParseState and check for a comment after a
whitespace. Also return the current position of the iter to correctly
strip the comments of from the line to prevent quoted comments or
non-whitespace surrounded hash chars.

Also updated the tests to match these cases.
And added an example code to easily show the output.