### PR TITLE
Fix clippy lints

### DIFF
--- a/dotenv/src/errors.rs
+++ b/dotenv/src/errors.rs
@@ -6,12 +6,11 @@ use std::io;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     LineParse(String, usize),
     Io(io::Error),
     EnvVar(env::VarError),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Error {
@@ -43,7 +42,6 @@ impl fmt::Display for Error {
                 "Error parsing line: '{}', error at line index: {}",
                 line, error_index
             ),
-            _ => unreachable!(),
         }
     }
 }

--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -66,7 +66,7 @@ impl<'a> LineParser<'a> {
             return Ok(Some((key, String::new())));
         }
 
-        let parsed_value = parse_value(self.line, &mut self.substitution_data)?;
+        let parsed_value = parse_value(self.line, self.substitution_data)?;
         self.substitution_data
             .insert(key.clone(), Some(parsed_value.clone()));
 


### PR DESCRIPTION
- Remove unnecessary reference
- Use #[non_exhaustive]` annotation on `dotenvy::Error` enum

The second one is technically an incompatible API change. However, the whole point of the `__Nonexhaustive` variant pattern is to get callers to include a wildcard branch when matching, so you could argue it doesn't require a semver bump: anyone referring to that variant explicitly was doing it wrong. But I don't know if that's the normal expectation; this pattern is new to me.