### PR TITLE
deps: move `dirs` to dev-dependencies

### DIFF
--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -26,10 +26,10 @@ required-features = ["cli"]
 
 [dependencies]
 clap = { version = "3.2", optional = true }
-dirs = "4.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"
+dirs = "4.0"
 
 [features]
 cli = ["clap"]


### PR DESCRIPTION
`dirs` is only used in doctests, not in the library itself. So there is no need to install it for end users.