### PR TITLE
Add support for UTF-8 BOM encoding

### DIFF
--- a/dotenv/tests/test-ignore-bom.rs
+++ b/dotenv/tests/test-ignore-bom.rs
@@ -1,0 +1,22 @@
+mod common;
+
+use crate::common::*;
+use dotenvy::*;
+use std::{env, error::Error, result::Result};
+
+#[test]
+fn test_ignore_bom() -> Result<(), Box<dyn Error>> {
+    let bom = "\u{feff}";
+    let dir = tempdir_with_dotenv(&format!("{}TESTKEY=test_val", bom))?;
+
+    let mut path = env::current_dir()?;
+    path.push(".env");
+
+    from_path(&path)?;
+
+    assert_eq!(env::var("TESTKEY")?, "test_val");
+
+    env::set_current_dir(dir.path().parent().unwrap())?;
+    dir.close()?;
+    Ok(())
+}


### PR DESCRIPTION
The UTF-8 Byte Order Mark `\ufeff` will be ignored when parsing.

Add integration test to confirm.

See #27