### PR TITLE
Fix warnings

### DIFF
--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["dotenv", "env", "environment", "settings", "config"]
 license = "MIT"
 repository = "https://github.com/allan2/dotenvy"
 edition = "2018"
-rust = "1.58.1"
+rust-version = "1.58.1"
 
 [[bin]]
 name = "dotenvy"

--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -269,7 +269,7 @@ fn apply_substitution(
             .get(substitution_name)
             .unwrap_or(&None)
             .to_owned();
-        output.push_str(&stored_value.unwrap_or_else(String::new));
+        output.push_str(&stored_value.unwrap_or_default());
     };
 }
 
@@ -645,7 +645,7 @@ mod error_tests {
 
         if let Err(LineParse(wrong_value, index)) = &parsed_values[0] {
             assert_eq!(wrong_value, wrong_escape);
-            assert_eq!(*index, wrong_escape.find("\\").unwrap() + 1)
+            assert_eq!(*index, wrong_escape.find('\\').unwrap() + 1)
         } else {
             panic!("Expected the second value not to be parsed")
         }

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -17,7 +17,7 @@ homepage = "https://github.com/allan2/dotenvy"
 repository = "https://github.com/allan2/dotenvy"
 description = "A macro for compile time dotenv inspection"
 edition = "2018"
-rust = "1.58.1"
+rust-version = "1.58.1"
 
 [dependencies]
 dotenvy_codegen_impl = { version = "0.15", path = "../dotenv_codegen_impl" }

--- a/dotenv_codegen_impl/Cargo.toml
+++ b/dotenv_codegen_impl/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/allan2/dotenvy"
 repository = "https://github.com/allan2/dotenvy"
 description = "Internal implementation for dotenvy_codegen"
 edition = "2018"
-rust = "1.58.1"
+rust-version = "1.58.1"
 
 [dependencies]
 proc-macro2 = "1"


### PR DESCRIPTION
Clippy lints:

- Single-character string constant used as pattern.
- Use of `.unwrap_or_else(..)` to construct default value.

Cargo warning:

"Previously Unused manifest key: package.rust" warning fixed. The
manifest key according to [Cargo docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) should be `rust-version`.
