### PR TITLE
ci: add codecov comment to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
         with:
           version: 0.22.0
           args: --ignore-tests --workspace -- --test-threads 1
+          
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code_coverage_result
+          path: cobertura.xml
 
       # push steps
       - name: Upload to codecov.io
@@ -97,9 +103,18 @@ jobs:
         with:
           files: cobertura.xml
 
-      - name: Archive code coverage results
+      # pull request steps
+      - name: Note PR number
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          printf $PR_NUMBER > ./pr/pr_number
+
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v3
-        if: github.event_name == 'push'
         with:
-          name: code-coverage-report
-          path: cobertura.xml
+          name: pr_number
+          path: pr/

--- a/.github/workflows/codecov-comment.yml
+++ b/.github/workflows/codecov-comment.yml
@@ -1,0 +1,61 @@
+name: codecov-comment
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+jobs:
+  pr:
+    runs-on: ubuntu-latest
+    # Only run if workflow was successfully run on a pull_request event
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.workflow_run.event == 'pull_request') }}
+    env:
+      # ID of the pull_request's workflow run
+      PR_RUN_ID: ${{ github.event.workflow_run.id }}
+
+    steps:
+      - name: Get results
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ci
+          run_id: ${{ env.PR_RUN_ID }}
+          name: code_coverage_result
+
+      - name: Create report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: cobertura.xml
+          badge: true
+          format: markdown
+          hide_branch_rate: true
+          hide_complexity: true
+          indicators: false
+          output: both
+          thresholds: "50 75"
+
+      - name: Trim report
+        # get rid of unnecessary codcov info
+        # remove any line not containing a link or a comment
+        run: |
+          sed -i '/!\[\|<!--/!d' code-coverage-results.md
+
+      - name: Get PR number
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ci
+          run_id: ${{ env.PR_RUN_ID }}
+          name: pr_number
+
+      - name: Read PR number
+        id: read_pr
+        uses: andstor/file-reader-action@v1
+        with:
+          path: pr_number
+
+      - name: Add coverage PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.read_pr.outputs.contents }}
+          recreate: true
+          path: code-coverage-results.md


### PR DESCRIPTION
CI workflow that adds a code coverage comment to pull requests.

- Only runs if all the other checks pass
- Replaces comment on subsequent re-runs