### PR TITLE
Add support for Rust 1.56.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.58.1]
+        rust: [stable, beta, nightly, 1.56.1]
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## Changed
+
+- Minimum Supported Rust Version is now 1.56.1
+
 ## [0.15.6] - 2022-10-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/dotenvy.svg)](https://crates.io/crates/dotenvy)
 [![msrv
-1.58.1](https://img.shields.io/badge/msrv-1.58.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.58.1)
+1.56.1](https://img.shields.io/badge/msrv-1.56.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.56.1)
 [![ci](https://github.com/allan2/dotenvy/actions/workflows/ci.yml/badge.svg)](https://github.com/allan2/dotenvy/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenvy?logo=docs.rs)](https://docs.rs/dotenvy/)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The `dotenv!` macro provided by `dotenvy_macro` crate can be used.
 
 Warning: there is an outstanding issue with rust-analyzer ([rust-analyzer #9606](https://github.com/rust-analyzer/rust-analyzer/issues/9606)) related to the `dotenv!` macro
 
+## Minimum supported Rust version
+
+Currently: **1.56.1**
+
+We aim to support the latest 8 rustc versions - approximately 1 year. Increasing
+MSRV is _not_ considered a semver-breaking change.
+
 ## Why does this fork exist?
 
 The original dotenv crate has not been updated since June 26, 2020. Attempts to reach the authors and present maintainer were not successful ([dotenv-rs/dotenv #74](https://github.com/dotenv-rs/dotenv/issues/74)).

--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["dotenv", "env", "environment", "settings", "config"]
 license = "MIT"
 repository = "https://github.com/allan2/dotenvy"
 edition = "2018"
-rust-version = "1.58.1"
+rust-version = "1.56.1"
 
 [[bin]]
 name = "dotenvy"

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/dotenvy.svg)](https://crates.io/crates/dotenvy)
 [![msrv
-1.58.1](https://img.shields.io/badge/msrv-1.58.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.58.1)
+1.56.1](https://img.shields.io/badge/msrv-1.56.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.56.1)
 [![ci](https://github.com/allan2/dotenvy/actions/workflows/ci.yml/badge.svg)](https://github.com/allan2/dotenvy/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenvy?logo=docs.rs)](https://docs.rs/dotenvy/)
 

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -42,6 +42,13 @@ The `dotenv!` macro provided by `dotenvy_macro` crate can be used.
 
 Warning: there is an outstanding issue with rust-analyzer ([rust-analyzer #9606](https://github.com/rust-analyzer/rust-analyzer/issues/9606)) related to the `dotenv!` macro
 
+## Minimum supported Rust version
+
+Currently: **1.56.1**
+
+We aim to support the latest 8 rustc versions - approximately 1 year. Increasing
+MSRV is _not_ considered a semver-breaking change.
+
 ## Why does this fork exist?
 
 The original dotenv crate has not been updated since June 26, 2020. Attempts to reach the authors and present maintainer were not successful ([dotenv-rs/dotenv #74](https://github.com/dotenv-rs/dotenv/issues/74)).

--- a/dotenv/examples/list_variables.rs
+++ b/dotenv/examples/list_variables.rs
@@ -4,7 +4,7 @@ fn main() -> Result<(), Error> {
     dotenvy::dotenv()?;
     for item in dotenv_iter()? {
         let (key, val) = item?;
-        println!("{key}={val}");
+        println!("{}={}", key, val);
     }
     Ok(())
 }

--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -32,7 +32,7 @@ static START: Once = Once::new();
 ///
 /// ```no_run
 /// let value = dotenvy::var("HOME").unwrap();
-/// println!("{value}");  // prints `/home/foo`
+/// println!("{}", value);  // prints `/home/foo`
 /// ```
 pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String> {
     START.call_once(|| {
@@ -84,7 +84,7 @@ pub fn from_path<P: AsRef<Path>>(path: P) -> Result<()> {
 ///
 /// for item in dotenvy::from_path_iter(my_path.as_path()).unwrap() {
 ///   let (key, val) = item.unwrap();
-///   println!("{key}={val}");
+///   println!("{}={}", key, val);
 /// }
 /// ```
 pub fn from_path_iter<P: AsRef<Path>>(path: P) -> Result<Iter<File>> {
@@ -115,7 +115,7 @@ pub fn from_filename<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
 /// ```no_run
 /// for item in dotenvy::from_filename_iter("custom.env").unwrap() {
 ///     let (key, val) = item.unwrap();
-///     println!("{key}={val}");
+///     println!("{}={}", key, val);
 ///   }
 /// ```
 
@@ -158,7 +158,7 @@ pub fn from_read<R: io::Read>(reader: R) -> Result<()> {
 ///
 /// for item in dotenvy::from_read_iter(stream) {
 ///   let (key, val) = item.unwrap();
-///   println!("{key}={val}");
+///   println!("{}={}", key, val);
 /// }
 /// ```
 pub fn from_read_iter<R: io::Read>(reader: R) -> Iter<R> {
@@ -183,7 +183,7 @@ pub fn dotenv() -> Result<PathBuf> {
 /// ```
 /// for item in dotenvy::dotenv_iter().unwrap() {
 ///   let (key, val) = item.unwrap();
-///   println!("{key}={val}");
+///   println!("{}={}", key, val);
 /// }
 /// ```
 pub fn dotenv_iter() -> Result<iter::Iter<File>> {

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -17,7 +17,7 @@ homepage = "https://github.com/allan2/dotenvy"
 repository = "https://github.com/allan2/dotenvy"
 description = "A macro for compile time dotenv inspection"
 edition = "2018"
-rust-version = "1.58.1"
+rust-version = "1.56.1"
 
 [dependencies]
 dotenvy_codegen_impl = { version = "0.15", path = "../dotenv_codegen_impl" }

--- a/dotenv_codegen_impl/Cargo.toml
+++ b/dotenv_codegen_impl/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/allan2/dotenvy"
 repository = "https://github.com/allan2/dotenvy"
 description = "Internal implementation for dotenvy_codegen"
 edition = "2018"
-rust-version = "1.58.1"
+rust-version = "1.56.1"
 
 [dependencies]
 proc-macro2 = "1"


### PR DESCRIPTION
Closes #33 

- Remove format strings in doctests.
- Update `Cargo.toml`s.
- Update docs.
- Add MSRV policy to readmes.

## Policy

>We aim to support the latest 8 rustc versions - approximately 1 year.
>Increasing MSRV is _not_ considered a semver-breaking change.

Copied from: [once_cell](https://docs.rs/once_cell/latest/once_cell/#minimum-supported-rustc-version).

