### PR TITLE
feat: Implement overriding API methods and correct inconsistent naming

### DIFF
--- a/dotenv/src/iter.rs
+++ b/dotenv/src/iter.rs
@@ -21,7 +21,11 @@ impl<R: Read> Iter<R> {
         }
     }
 
-    /// Loads all variables found in the `reader` into the environment.
+    /// Loads all variables found in the `reader`, which not yet exist in the environment,
+    /// into the environment.
+    ///
+    /// If a variable is specified multiple times within the reader's data,
+    /// then the first occurrence is applied.
     pub fn load(mut self) -> Result<()> {
         self.remove_bom()?;
 
@@ -35,7 +39,11 @@ impl<R: Read> Iter<R> {
         Ok(())
     }
 
-    /// A version of [load] that overrides older variables in case of duplicates.
+    /// Loads all variables found in the `reader` into the environment,
+    /// overriding any existing environment variables of the same name.
+    ///
+    /// If a variable is specified multiple times within the reader's data,
+    /// then the last occurrence is applied.
     pub fn overload(mut self) -> Result<()> {
         self.remove_bom()?;
 

--- a/dotenv/src/iter.rs
+++ b/dotenv/src/iter.rs
@@ -21,8 +21,8 @@ impl<R: Read> Iter<R> {
         }
     }
 
-    /// Loads all variables found in the `reader`, which not yet exist in the environment,
-    /// into the environment.
+    /// Loads all variables found in the `reader` into the environment,
+    /// preserving any existing environment variables of the same name.
     ///
     /// If a variable is specified multiple times within the reader's data,
     /// then the first occurrence is applied.
@@ -44,7 +44,7 @@ impl<R: Read> Iter<R> {
     ///
     /// If a variable is specified multiple times within the reader's data,
     /// then the last occurrence is applied.
-    pub fn overload(mut self) -> Result<()> {
+    pub fn load_override(mut self) -> Result<()> {
         self.remove_bom()?;
 
         for item in self {

--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -67,7 +67,7 @@ pub fn vars() -> Vars {
 /// file, the *first one* is applied.
 ///
 /// If you wish to ensure all variables are loaded from your *.env* file, ignoring variables
-/// already existing in the environment, then use [`from_path_overload()`] instead.
+/// already existing in the environment, then use [`from_path_override`] instead.
 ///
 /// # Examples
 ///
@@ -88,9 +88,9 @@ pub fn from_path<P: AsRef<Path>>(path: P) -> Result<()> {
 /// Where multiple declarations for the same environment variable exist in your *.env* file, the
 /// *last one* is applied.
 ///
-/// If you want the existing environment to take precendence,
+/// If you want the existing environment to take precedence,
 /// or if you want to be able to override environment variables on the command line,
-/// then use [`from_path()`] instead.
+/// then use [`from_path`] instead.
 ///
 /// # Examples
 ///
@@ -98,14 +98,14 @@ pub fn from_path<P: AsRef<Path>>(path: P) -> Result<()> {
 /// use dirs::home_dir;
 ///
 /// let my_path = home_dir().map(|a| a.join("/absolute/path/.env")).unwrap();
-/// dotenvy::from_path_overload(my_path.as_path());
+/// dotenvy::from_path_override(my_path.as_path());
 /// ```
-pub fn from_path_overload<P: AsRef<Path>>(path: P) -> Result<()> {
+pub fn from_path_override<P: AsRef<Path>>(path: P) -> Result<()> {
     let iter = Iter::new(File::open(path).map_err(Error::Io)?);
-    iter.overload()
+    iter.load_override()
 }
 
-///  Returns an iterator over environment variables from the specified path.
+/// Returns an iterator over environment variables from the specified path.
 ///
 /// # Examples
 ///
@@ -132,14 +132,14 @@ pub fn from_path_iter<P: AsRef<Path>>(path: P) -> Result<Iter<File>> {
 /// file, the *first one* is applied.
 ///
 /// If you wish to ensure all variables are loaded from your *.env* file, ignoring variables
-/// already existing in the environment, then use [`from_filename_overload()`] instead.
+/// already existing in the environment, then use [`from_filename_override`] instead.
 ///
 /// # Examples
 /// ```no_run
 /// dotenvy::from_filename("custom.env").unwrap();
 /// ```
 ///
-/// It is also possible to load from a typical *.env* file like so. However, using [`dotenv()`] is preferred.
+/// It is also possible to load from a typical *.env* file like so. However, using [`dotenv`] is preferred.
 ///
 /// ```
 /// dotenvy::from_filename(".env").unwrap();
@@ -156,23 +156,23 @@ pub fn from_filename<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
 /// Where multiple declarations for the same environment variable exist in your *.env* file, the
 /// *last one* is applied.
 ///
-/// If you want the existing environment to take precendence,
+/// If you want the existing environment to take precedence,
 /// or if you want to be able to override environment variables on the command line,
-/// then use [`from_filename()`] instead.
+/// then use [`from_filename`] instead.
 ///
 /// # Examples
 /// ```no_run
-/// dotenvy::from_filename_overload("custom.env").unwrap();
+/// dotenvy::from_filename_override("custom.env").unwrap();
 /// ```
 ///
-/// It is also possible to load from a typical *.env* file like so. However, using [`overload()`] is preferred.
+/// It is also possible to load from a typical *.env* file like so. However, using [`dotenv_override`] is preferred.
 ///
 /// ```
-/// dotenvy::from_filename_overload(".env").unwrap();
+/// dotenvy::from_filename_override(".env").unwrap();
 /// ```
-pub fn from_filename_overload<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
+pub fn from_filename_override<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
     let (path, iter) = Finder::new().filename(filename.as_ref()).find()?;
-    iter.overload()?;
+    iter.load_override()?;
     Ok(path)
 }
 
@@ -203,9 +203,9 @@ pub fn from_filename_iter<P: AsRef<Path>>(filename: P) -> Result<Iter<File>> {
 /// the *first one* is applied.
 ///
 /// If you wish to ensure all variables are loaded from your `reader`, ignoring variables
-/// already existing in the environment, then use [`from_read_overload()`] instead.
+/// already existing in the environment, then use [`from_read_override`] instead.
 ///
-/// For regular files, use [`from_path()`] or [`from_filename()`].
+/// For regular files, use [`from_path`] or [`from_filename`].
 ///
 /// # Examples
 ///
@@ -231,11 +231,11 @@ pub fn from_read<R: io::Read>(reader: R) -> Result<()> {
 /// Where multiple declarations for the same environment variable exist in your `reader`, the
 /// *last one* is applied.
 ///
-/// If you want the existing environment to take precendence,
+/// If you want the existing environment to take precedence,
 /// or if you want to be able to override environment variables on the command line,
-/// then use [`from_read()`] instead.
+/// then use [`from_read`] instead.
 ///
-/// For regular files, use [`from_path_overload()`] or [`from_filename_overload()`].
+/// For regular files, use [`from_path_override`] or [`from_filename_override`].
 ///
 /// # Examples
 /// ```no_run
@@ -244,11 +244,11 @@ pub fn from_read<R: io::Read>(reader: R) -> Result<()> {
 /// use std::os::unix::net::UnixStream;
 ///
 /// let mut stream = UnixStream::connect("/some/socket").unwrap();
-/// dotenvy::from_read_overload(stream).unwrap();
+/// dotenvy::from_read_override(stream).unwrap();
 /// ```
-pub fn from_read_overload<R: io::Read>(reader: R) -> Result<()> {
+pub fn from_read_override<R: io::Read>(reader: R) -> Result<()> {
     let iter = Iter::new(reader);
-    iter.overload()?;
+    iter.load_override()?;
     Ok(())
 }
 
@@ -281,7 +281,7 @@ pub fn from_read_iter<R: io::Read>(reader: R) -> Iter<R> {
 /// file, the *first one* is applied.
 ///
 /// If you wish to ensure all variables are loaded from your *.env* file, ignoring variables
-/// already existing in the environment, then use [`overload()`] instead.
+/// already existing in the environment, then use [`dotenv_override`] instead.
 ///
 /// An error will be returned if the file is not found.
 ///
@@ -302,18 +302,18 @@ pub fn dotenv() -> Result<PathBuf> {
 /// Where multiple declarations for the same environment variable exist in your *.env* file, the
 /// *last one* is applied.
 ///
-/// If you want the existing environment to take precendence,
+/// If you want the existing environment to take precedence,
 /// or if you want to be able to override environment variables on the command line,
-/// then use [`dotenv()`] instead.
+/// then use [`dotenv`] instead.
 ///
 /// # Examples
 /// ```
-/// use dotenvy::overload;
-/// overload().ok();
+/// use dotenvy::dotenv_override;
+/// dotenv_override().ok();
 /// ```
-pub fn overload() -> Result<PathBuf> {
+pub fn dotenv_override() -> Result<PathBuf> {
     let (path, iter) = Finder::new().find()?;
-    iter.overload()?;
+    iter.load_override()?;
     Ok(path)
 }
 

--- a/dotenv/tests/common/mod.rs
+++ b/dotenv/tests/common/mod.rs
@@ -4,6 +4,7 @@ use std::{env, io};
 use tempfile::{tempdir, TempDir};
 
 pub fn tempdir_with_dotenv(dotenv_text: &str) -> io::Result<TempDir> {
+    env::set_var("EXISTING", "from_env");
     let dir = tempdir()?;
     env::set_current_dir(dir.path())?;
     let dotenv_path = dir.path().join(".env");
@@ -15,5 +16,5 @@ pub fn tempdir_with_dotenv(dotenv_text: &str) -> io::Result<TempDir> {
 
 #[allow(dead_code)]
 pub fn make_test_dotenv() -> io::Result<TempDir> {
-    tempdir_with_dotenv("TESTKEY=test_val")
+    tempdir_with_dotenv("TESTKEY=test_val\nTESTKEY=test_val_overridden\nEXISTING=from_file")
 }

--- a/dotenv/tests/test-default-location-overload.rs
+++ b/dotenv/tests/test-default-location-overload.rs
@@ -8,14 +8,12 @@ use crate::common::*;
 
 #[test]
 fn test_overload() -> Result<(), Box<dyn Error>> {
-    let dir = tempdir_with_dotenv(
-        "
-var=old
-var=new
-",
-    )?;
+    let dir = make_test_dotenv()?;
+
     overload()?;
-    assert_eq!(var("var")?, "new");
+
+    assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
+    assert_eq!(env::var("EXISTING")?, "from_file");
 
     env::set_current_dir(dir.path().parent().unwrap())?;
     dir.close()?;

--- a/dotenv/tests/test-default-location-override.rs
+++ b/dotenv/tests/test-default-location-override.rs
@@ -1,15 +1,16 @@
 mod common;
 
-use dotenvy::*;
 use std::{env, error::Error, result::Result};
+
+use dotenvy::*;
 
 use crate::common::*;
 
 #[test]
-fn test_from_filename() -> Result<(), Box<dyn Error>> {
+fn test_default_location_override() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
-    from_filename_overload(".env")?;
+    dotenv_override()?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
     assert_eq!(env::var("EXISTING")?, "from_file");

--- a/dotenv/tests/test-from-filename-overload.rs
+++ b/dotenv/tests/test-from-filename-overload.rs
@@ -1,19 +1,18 @@
 mod common;
 
 use dotenvy::*;
-
 use std::{env, error::Error, result::Result};
 
 use crate::common::*;
 
 #[test]
-fn test_default_location() -> Result<(), Box<dyn Error>> {
+fn test_from_filename() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
-    dotenv()?;
+    from_filename_overload(".env")?;
 
-    assert_eq!(env::var("TESTKEY")?, "test_val");
-    assert_eq!(env::var("EXISTING")?, "from_env");
+    assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
+    assert_eq!(env::var("EXISTING")?, "from_file");
 
     env::set_current_dir(dir.path().parent().unwrap())?;
     dir.close()?;

--- a/dotenv/tests/test-from-filename-override.rs
+++ b/dotenv/tests/test-from-filename-override.rs
@@ -1,16 +1,15 @@
 mod common;
 
-use std::{env, error::Error, result::Result};
-
 use dotenvy::*;
+use std::{env, error::Error, result::Result};
 
 use crate::common::*;
 
 #[test]
-fn test_overload() -> Result<(), Box<dyn Error>> {
+fn test_from_filename_override() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
-    overload()?;
+    from_filename_override(".env")?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
     assert_eq!(env::var("EXISTING")?, "from_file");

--- a/dotenv/tests/test-from-filename.rs
+++ b/dotenv/tests/test-from-filename.rs
@@ -12,6 +12,7 @@ fn test_from_filename() -> Result<(), Box<dyn Error>> {
     from_filename(".env")?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val");
+    assert_eq!(env::var("EXISTING")?, "from_env");
 
     env::set_current_dir(dir.path().parent().unwrap())?;
     dir.close()?;

--- a/dotenv/tests/test-from-path-overload.rs
+++ b/dotenv/tests/test-from-path-overload.rs
@@ -11,10 +11,10 @@ fn test_from_path() -> Result<(), Box<dyn Error>> {
     let mut path = env::current_dir()?;
     path.push(".env");
 
-    from_path(&path)?;
+    from_path_overload(&path)?;
 
-    assert_eq!(env::var("TESTKEY")?, "test_val");
-    assert_eq!(env::var("EXISTING")?, "from_env");
+    assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
+    assert_eq!(env::var("EXISTING")?, "from_file");
 
     env::set_current_dir(dir.path().parent().unwrap())?;
     dir.close()?;

--- a/dotenv/tests/test-from-path-override.rs
+++ b/dotenv/tests/test-from-path-override.rs
@@ -5,13 +5,13 @@ use dotenvy::*;
 use std::{env, error::Error, result::Result};
 
 #[test]
-fn test_from_path() -> Result<(), Box<dyn Error>> {
+fn test_from_path_override() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
     let mut path = env::current_dir()?;
     path.push(".env");
 
-    from_path_overload(&path)?;
+    from_path_override(&path)?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
     assert_eq!(env::var("EXISTING")?, "from_file");

--- a/dotenv/tests/test-from-read-overload.rs
+++ b/dotenv/tests/test-from-read-overload.rs
@@ -1,0 +1,20 @@
+mod common;
+
+use dotenvy::*;
+use std::{env, error::Error, fs::File, result::Result};
+
+use crate::common::*;
+
+#[test]
+fn test_from_read() -> Result<(), Box<dyn Error>> {
+    let dir = make_test_dotenv()?;
+
+    from_read_overload(File::open(".env")?)?;
+
+    assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
+    assert_eq!(env::var("EXISTING")?, "from_file");
+
+    env::set_current_dir(dir.path().parent().unwrap())?;
+    dir.close()?;
+    Ok(())
+}

--- a/dotenv/tests/test-from-read-override.rs
+++ b/dotenv/tests/test-from-read-override.rs
@@ -6,10 +6,10 @@ use std::{env, error::Error, fs::File, result::Result};
 use crate::common::*;
 
 #[test]
-fn test_from_read() -> Result<(), Box<dyn Error>> {
+fn test_from_read_override() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
-    from_read_overload(File::open(".env")?)?;
+    from_read_override(File::open(".env")?)?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
     assert_eq!(env::var("EXISTING")?, "from_file");

--- a/dotenv/tests/test-from-read.rs
+++ b/dotenv/tests/test-from-read.rs
@@ -1,16 +1,15 @@
 mod common;
 
 use dotenvy::*;
-
-use std::{env, error::Error, result::Result};
+use std::{env, error::Error, fs::File, result::Result};
 
 use crate::common::*;
 
 #[test]
-fn test_default_location() -> Result<(), Box<dyn Error>> {
+fn test_from_read() -> Result<(), Box<dyn Error>> {
     let dir = make_test_dotenv()?;
 
-    dotenv()?;
+    from_read(File::open(".env")?)?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val");
     assert_eq!(env::var("EXISTING")?, "from_env");


### PR DESCRIPTION
This is a successor to https://github.com/allan2/dotenvy/pull/17 and the preferred alternative to https://github.com/allan2/dotenvy/pull/46.

# This PR

- Adds overriding variants to all relevant public API methods.
- Fixes documentation.
- Adds missing test for `from_read()`.
- Tests non-overriding behavior with greater precision.
- Tests overriding behavior correctly.
- Fixes some inconsistent test formatting.
- *Difference from #46:* Fixes inconsistent naming. See discussion in #46 for details.
