### PR TITLE
docs: change dotenvy_codegen to dotenvy_macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library loads environment variables from a _.env_ file. This is convenient 
 ## Components
 
 1. [`dotenvy`](https://crates.io/crates/dotenvy) crate - A well-maintained fork of the `dotenv` crate.
-2. [`dotenvy_macro`](https://crates.io/crates/dotenvy_codegen) crate - A macro for compile time dotenv inspection. This is a fork of `dotenv_codegen`.
+2. [`dotenvy_macro`](https://crates.io/crates/dotenvy_macro) crate - A macro for compile time dotenv inspection. This is a fork of `dotenv_codegen`.
 3. `dotenvy` CLI tool for running a command using the environment from a _.env_ file (currently Unix only)
 
 ## Usage

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -15,7 +15,7 @@ This library loads environment variables from a _.env_ file. This is convenient 
 ## Components
 
 1. [`dotenvy`](https://crates.io/crates/dotenvy) crate - A well-maintained fork of the `dotenv` crate.
-2. [`dotenvy_macro`](https://crates.io/crates/dotenvy_codegen) crate - A macro for compile time dotenv inspection. This is a fork of `dotenv_codegen`.
+2. [`dotenvy_macro`](https://crates.io/crates/dotenvy_macro) crate - A macro for compile time dotenv inspection. This is a fork of `dotenv_codegen`.
 3. `dotenvy` CLI tool for running a command using the environment from a _.env_ file (currently Unix only)
 
 ## Usage

--- a/dotenv_codegen/README.md
+++ b/dotenv_codegen/README.md
@@ -1,7 +1,7 @@
 # dotenvy_codgen
 
-[![crates.io](https://img.shields.io/crates/v/dotenvy_codegen.svg)](https://crates.io/crates/dotenvy_codgen)
-[![Released API docs](https://docs.rs/dotenvy_codegen/badge.svg)](https://docs.rs/dotenvy_codegen)
+[![crates.io](https://img.shields.io/crates/v/dotenvy_macro.svg)](https://crates.io/crates/dotenvy_macro)
+[![Released API docs](https://docs.rs/dotenvy_macro/badge.svg)](https://docs.rs/dotenvy_macro)
 
 A macro for compile time dotenv inspection.
 

--- a/dotenv_codegen/README.md
+++ b/dotenv_codegen/README.md
@@ -1,4 +1,4 @@
-# dotenvy_codgen
+# dotenvy_macro
 
 [![crates.io](https://img.shields.io/crates/v/dotenvy_macro.svg)](https://crates.io/crates/dotenvy_macro)
 [![Released API docs](https://docs.rs/dotenvy_macro/badge.svg)](https://docs.rs/dotenvy_macro)


### PR DESCRIPTION
The dotenvy_codegen crate was renamed to dotenvy_macro (#2, cd0e6043fb4a80a6ae8924f99a413c2efaddb536) but it is still called dotenvy_codegen a lot in the docs. This fixes this. Especially because the links still pointed to the yanked crate.