### PR TITLE
fix: Publish `crate::iter::Iter` as `crate::Iter`.

### DIFF
--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::Once;
 
 pub use crate::errors::*;
 use crate::find::Finder;
-use crate::iter::Iter;
+pub use crate::iter::Iter;
 
 static START: Once = Once::new();
 


### PR DESCRIPTION
Proposal for #48 