### PR TITLE
fix(docs): Write user-centric documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Minimum Supported Rust Version is now 1.56.1
 - Removed internal `dotenv_codegen_impl` crate and `proc_macro_hack` dependency
+- Rewrote most documentation ([PR #54](https://github.com/allan2/dotenvy/pull/54) by [LeoniePhiline](https://github.com/LeoniePhiline)
 
 ## [0.15.6] - 2022-10-17
 

--- a/dotenv/src/iter.rs
+++ b/dotenv/src/iter.rs
@@ -26,6 +26,12 @@ impl<R: Read> Iter<R> {
     ///
     /// If a variable is specified multiple times within the reader's data,
     /// then the first occurrence is applied.
+    ///
+    /// # Errors
+    ///
+    /// An [`Error::Io`] is returned if the provided `reader` is not readable.
+    ///
+    /// An [`Error::LineParse`] is returned if the provided `reader` produces invalid declarations.
     pub fn load(mut self) -> Result<()> {
         self.remove_bom()?;
 
@@ -44,6 +50,12 @@ impl<R: Read> Iter<R> {
     ///
     /// If a variable is specified multiple times within the reader's data,
     /// then the last occurrence is applied.
+    ///
+    /// # Errors
+    ///
+    /// An [`Error::Io`] is returned if the provided `reader` is not readable.
+    ///
+    /// An [`Error::LineParse`] is returned if the provided `reader` produces invalid declarations.
     pub fn load_override(mut self) -> Result<()> {
         self.remove_bom()?;
 


### PR DESCRIPTION
# This PR

Fixes #53

## Details

- Adds user-centric documentation to public functions (including `Iter` - see #51).
- Adds an **Errors** section to each function's documentation. See https://rust-lang.github.io/api-guidelines/documentation.html#function-docs-include-error-panic-and-safety-considerations-c-failure
- Clarifies where auto-discovery is used and how to load a specific file instead.
- Clarifies where a specific file is loaded and how to use auto-discovery instead.
- Clarifies where errors are silenced.
- Clarifies where once loaded variables are not loaded again on a repeated call.
- Unifies doc formatting (e.g. blank lines after heading)
- Makes `Result` returns explicit where they were previously inconsistent with other parts of the crate.
- Consistently uses present tense for all behavior descriptions.