### PR TITLE
Add dev prod example

### DIFF
--- a/examples/.env
+++ b/examples/.env
@@ -1,0 +1,1 @@
+HOST=dev.com

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = ["*"]
+exclude = ["target"]
+resolver = "2"

--- a/examples/dev-prod/Cargo.toml
+++ b/examples/dev-prod/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example-dev-prod"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+dotenvy = { path = "../../dotenv" }

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -18,7 +18,7 @@ enum AppEnv {
 /// 2) `APP_ENV=dev HOST=prod.com cargo run`
 /// 3) `APP_ENV=prod cargo run`
 ///
-/// To have the .env file take priority, use `dotenv_orderride()`.
+/// To have the .env file take priority, use `dotenv_override()`.
 /// Try replacing `dotenv()` with `dotenv_override()` on line 2 and re-running command 2.
 fn main() {
     let app_env = std::env::var("APP_ENV")

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -52,7 +52,7 @@ impl FromStr for AppEnv {
 }
 
 impl fmt::Display for AppEnv {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AppEnv::Dev => write!(f, "dev"),
             AppEnv::Prod => write!(f, "prod"),

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
+    env,
     fmt::{self},
-    str::FromStr,
 };
 
 #[derive(PartialEq)]
@@ -14,17 +14,14 @@ enum AppEnv {
 ///  - loads from the envrironment in prod mode
 ///
 /// A few commands to try:
-/// 1) `APP_ENV=prod HOST=prod.com cargo run`
-/// 2) `APP_ENV=dev HOST=prod.com cargo run`
-/// 3) `APP_ENV=prod cargo run`
-///
-/// To have the .env file take priority, use `dotenv_override()`.
-/// Try replacing `dotenv()` with `dotenv_override()` on line 2 and re-running command 2.
+/// 1) `cargo run`
+/// 2) `APP_ENV=prod cargo run`
+/// 3) `APP_ENV=prod HOST=prod.com cargo run`
 fn main() {
-    let app_env = std::env::var("APP_ENV")
-        .unwrap_or("dev".to_owned())
-        .parse::<AppEnv>()
-        .unwrap();
+    let app_env = match env::var("APP_ENV") {
+        Ok(v) if v == "prod" => AppEnv::Prod,
+        _ => AppEnv::Dev,
+    };
 
     println!("Running in {app_env} mode");
 
@@ -37,18 +34,6 @@ fn main() {
 
     let host = env::var("HOST").expect("HOST not set");
     println!("Host: {host}");
-}
-
-impl FromStr for AppEnv {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "dev" => Ok(AppEnv::Dev),
-            "prod" => Ok(AppEnv::Prod),
-            _ => Err(format!("Unknown app env: {s}")),
-        }
-    }
 }
 
 impl fmt::Display for AppEnv {

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         };
     }
 
-    let host = dotenvy::var("HOST").expect("HOST not set");
+    let host = env::var("HOST").expect("HOST not set");
     println!("Host: {host}");
 }
 

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -1,0 +1,61 @@
+use std::{
+    fmt::{self},
+    str::FromStr,
+};
+
+#[derive(PartialEq)]
+enum AppEnv {
+    Dev,
+    Prod,
+}
+
+/// A common setup that:
+///  - loads from a .env file in dev mode
+///  - loads from the envrironment in prod mode
+///
+/// A few commands to try:
+/// 1) `APP_ENV=prod HOST=prod.com cargo run`
+/// 2) `APP_ENV=dev HOST=prod.com cargo run`
+/// 3) `APP_ENV=prod cargo run`
+///
+/// To have the .env file take priority, use `dotenv_orderride()`.
+/// Try replacing `dotenv()` with `dotenv_override()` on line 2 and re-running command 2.
+fn main() {
+    let app_env = std::env::var("APP_ENV")
+        .unwrap_or("dev".to_owned())
+        .parse::<AppEnv>()
+        .unwrap();
+
+    println!("Running in {app_env} mode");
+
+    if app_env == AppEnv::Dev {
+        match dotenvy::dotenv() {
+            Ok(path) => println!(".env read successfully from {}", path.display()),
+            Err(e) => println!("Could not load .env file: {e}"),
+        };
+    }
+
+    let host = dotenvy::var("HOST").expect("HOST not set");
+    println!("Host: {host}");
+}
+
+impl FromStr for AppEnv {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dev" => Ok(AppEnv::Dev),
+            "prod" => Ok(AppEnv::Prod),
+            _ => Err(format!("Unknown app env: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for AppEnv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppEnv::Dev => write!(f, "dev"),
+            AppEnv::Prod => write!(f, "prod"),
+        }
+    }
+}


### PR DESCRIPTION
Many recurring questions from users are about overriding or how to handle errors when a .env file is found or not found.

This PR
- creates an *examples* directory
- adds an example showing how behaviour can differ across dev and prod modes