### PR TITLE
Allow dotenv macro to provide a default value

### DIFF
--- a/dotenv_codegen/tests/basic_dotenv_macro.rs
+++ b/dotenv_codegen/tests/basic_dotenv_macro.rs
@@ -14,3 +14,11 @@ fn two_argument_form_works() {
         "'quotes within quotes'"
     );
 }
+
+#[test]
+fn optional_dotenv() {
+    assert_eq!(
+        dotenvy_macro::try_dotenv!("non existing env", "unexpected sentence"),
+        "unexpected sentence"
+    );
+}


### PR DESCRIPTION
My use case is:
- when building for production, I want my environment to be **embedded in the binary** (I'm building on wasm)
  - `dotenv!("env_key")` fits my needs 🎉 
- when building on development, I'd like to be able to pass a **default value** (which could be a runtime value, such as an enviroment variable)
  - `dotenv!("env_key")` fails the compilation 👎 

This PR adds a `try_dotenv!("env_key", "default value")` which does not create a compilation error if the second parameter is correct.