### PR TITLE
create example from-path

### DIFF
--- a/examples/from-path/Cargo.toml
+++ b/examples/from-path/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example-from-path"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+dotenvy = { path = "../../dotenv" }

--- a/examples/from-path/src/main.rs
+++ b/examples/from-path/src/main.rs
@@ -1,0 +1,28 @@
+///! Use dotenvy with custom .env file path
+///!
+///! Run:
+///! ```sh
+///! cd examples/from-path
+///! cargo run
+///! ```   
+use dotenvy::{from_path, Result};
+use std::{env::current_dir, ffi::OsStr};
+
+/// Get dotenv file path from CWD
+fn dotenv_file_path() -> String {
+    let path = current_dir().unwrap();
+    let dir = path.parent().unwrap();
+    format!("{:?}/.env", dir).replace("\"", "")
+}
+
+fn dotenv_init() -> Result<()> {
+    from_path(OsStr::new(&dotenv_file_path()))
+}
+
+fn main() {
+    dotenv_init().expect(".env file is missing");
+    println!(
+        "host: {}",
+        std::env::var("HOST").expect("HOST must be set.")
+    );
+}


### PR DESCRIPTION
Method  `from_path` is relevant when the `.env` file is located in a directory lower in the hierarchy from `CWD`. An example of using `from_path` will not be superfluous.