### PR TITLE
Update clap to newest version

### DIFF
--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -25,7 +25,7 @@ name = "dotenvy"
 required-features = ["cli"]
 
 [dependencies]
-clap = { version = "3.2", optional = true }
+clap = { version = "4.3.11", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/dotenv/src/bin/dotenvy.rs
+++ b/dotenv/src/bin/dotenvy.rs
@@ -33,12 +33,11 @@ fn main() {
             Arg::new("FILE")
                 .short('f')
                 .long("file")
-                .takes_value(true)
                 .help("Use a specific .env file (defaults to .env)"),
         )
         .get_matches();
 
-    match matches.value_of("FILE") {
+    match matches.get_one::<String>("FILE") {
         None => dotenvy::dotenv(),
         Some(file) => dotenvy::from_filename(file),
     }
@@ -47,8 +46,8 @@ fn main() {
     let mut command = match matches.subcommand() {
         Some((name, matches)) => {
             let args = matches
-                .values_of("")
-                .map(|v| v.collect())
+                .get_many("")
+                .map(|v| v.copied().collect())
                 .unwrap_or(Vec::new());
 
             make_command(name, args)


### PR DESCRIPTION
This PR updates clap to the newest version.
I was using dotenvy in a project and I saw it duplicating my clap dependency due to using an old version.

This change doesn't break anything as far as I'm aware as we don't expose any of clap's internals ourselves.