### PR TITLE
Update MSRV to 1.64.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.56.1]
+        rust: [stable, beta, nightly, 1.64.0]
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.15.7] - 2023-03-22
 
 ### Added
@@ -114,7 +116,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed dotenv_codegen_impl to dotenv_codegen_implementation since we no longer own the original crate.
 - Update code to 2018 edition
 
-[Unreleased]: https://github.com/allan2/dotenvy/compare/v0.15.6...HEAD
+[Unreleased]: https://github.com/allan2/dotenvy/compare/v0.15.7...HEAD
+[0.15.7]: https://github.com/allan2/dotenvy/releases/tag/v0.15.7
 [0.15.6]: https://github.com/allan2/dotenvy/releases/tag/v0.15.6
 [0.15.5]: https://github.com/allan2/dotenvy/releases/tag/v0.15.5
 [0.15.4]: https://github.com/allan2/dotenvy/releases/tag/v0.15.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- MSRV updated to 1.64.0
+
 ## [0.15.7] - 2023-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/dotenvy.svg)](https://crates.io/crates/dotenvy)
 [![msrv
-1.56.1](https://img.shields.io/badge/msrv-1.56.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.56.1)
+1.64.0](https://img.shields.io/badge/msrv-1.64.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.64.0)
 [![ci](https://github.com/allan2/dotenvy/actions/workflows/ci.yml/badge.svg)](https://github.com/allan2/dotenvy/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenvy?logo=docs.rs)](https://docs.rs/dotenvy/)
 
@@ -42,7 +42,7 @@ The `dotenv!` macro provided by `dotenvy_macro` crate can be used.
 
 ## Minimum supported Rust version
 
-Currently: **1.56.1**
+Currently: **1.64.0**
 
 We aim to support the latest 8 rustc versions - approximately 1 year. Increasing
 MSRV is _not_ considered a semver-breaking change.

--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["dotenv", "env", "environment", "settings", "config"]
 license = "MIT"
 repository = "https://github.com/allan2/dotenvy"
 edition = "2018"
-rust-version = "1.56.1"
+rust-version = "1.64.0"
 
 [[bin]]
 name = "dotenvy"

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/dotenvy.svg)](https://crates.io/crates/dotenvy)
 [![msrv
-1.56.1](https://img.shields.io/badge/msrv-1.56.1-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.56.1)
+1.64.0](https://img.shields.io/badge/msrv-1.64.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.64.0)
 [![ci](https://github.com/allan2/dotenvy/actions/workflows/ci.yml/badge.svg)](https://github.com/allan2/dotenvy/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenvy?logo=docs.rs)](https://docs.rs/dotenvy/)
 
@@ -47,7 +47,7 @@ Warning: there is an outstanding issue with rust-analyzer ([rust-analyzer #9606]
 
 ## Minimum supported Rust version
 
-Currently: **1.56.1**
+Currently: **1.64.0**
 
 We aim to support the latest 8 rustc versions - approximately 1 year. Increasing
 MSRV is _not_ considered a semver-breaking change.

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://github.com/allan2/dotenvy"
 repository = "https://github.com/allan2/dotenvy"
 description = "A macro for compile time dotenv inspection"
 edition = "2018"
-rust-version = "1.56.1"
+rust-version = "1.64.0"
 
 [dependencies]
 proc-macro2 = "1"


### PR DESCRIPTION
Our Minimum Supported Rust Verison [policy](https://github.com/allan2/dotenvy#minimum-supported-rust-version) is to support the last 8 rustc versions. As of 2023-08-08 that is from version 1.63.0 onwards.

Clap's MSRV is [1.64.0](https://github.com/clap-rs/clap/blob/ee1388c0a31fcf0f60a7a93b70e1b20058df6832/.github/workflows/ci.yml#L87C14-L87C14), and we have a [PR](#77) to update to the lastest version. So I have bumped our MSRV to match.

The current CI tests do not pass with version 1.56.1 (due to dependencies having newer MSRVs) so I think it is worth doing now. 