### PR TITLE
Fix clippy lints

### DIFF
--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -180,7 +180,7 @@ fn parse_value(
                         } else {
                             apply_substitution(
                                 substitution_data,
-                                &substitution_name.drain(..).collect::<String>(),
+                                &std::mem::take(&mut substitution_name),
                                 &mut output,
                             );
                             if c == '$' {
@@ -200,7 +200,7 @@ fn parse_value(
                             substitution_mode = SubstitutionMode::None;
                             apply_substitution(
                                 substitution_data,
-                                &substitution_name.drain(..).collect::<String>(),
+                                &std::mem::take(&mut substitution_name),
                                 &mut output,
                             );
                         } else {
@@ -250,7 +250,7 @@ fn parse_value(
     } else {
         apply_substitution(
             substitution_data,
-            &substitution_name.drain(..).collect::<String>(),
+            &std::mem::take(&mut substitution_name),
             &mut output,
         );
         Ok(output)


### PR DESCRIPTION
Clippy linting had some complaints, as seen in https://github.com/allan2/dotenvy/actions/runs/6670434445/job/18130275180:

    warning: you seem to be trying to move all elements into a new `String`
       --> dotenv/src/parse.rs:183:34
        |
    183 | ...                   &substitution_name.drain(..).collect::<String>(),
        |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut substitution_name)`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drain_collect
        = note: `#[warn(clippy::drain_collect)]` on by default

All reported instances of that lint are fixed.