### PR TITLE
Remove redundant explicit link target in documentation

### DIFF
--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -215,7 +215,7 @@ pub fn from_filename_iter<P: AsRef<Path>>(filename: P) -> Result<Iter<File>> {
     Ok(iter)
 }
 
-/// Loads environment variables from [`io::Read`](std::io::Read).
+/// Loads environment variables from [`io::Read`].
 ///
 /// This is useful for loading environment variables from IPC or the network.
 ///
@@ -249,7 +249,7 @@ pub fn from_read<R: io::Read>(reader: R) -> Result<()> {
     Ok(())
 }
 
-/// Loads environment variables from [`io::Read`](std::io::Read),
+/// Loads environment variables from [`io::Read`],
 /// overriding existing environment variables.
 ///
 /// This is useful for loading environment variables from IPC or the network.
@@ -281,7 +281,7 @@ pub fn from_read_override<R: io::Read>(reader: R) -> Result<()> {
     Ok(())
 }
 
-/// Returns an iterator over environment variables from [`io::Read`](std::io::Read).
+/// Returns an iterator over environment variables from [`io::Read`].
 ///
 /// # Examples
 ///


### PR DESCRIPTION
When the CI tries to generate the documentation, it fails with

    error: redundant explicit link target
    Error:    --> dotenv/src/lib.rs:218:51
        |
    218 | /// Loads environment variables from [`io::Read`](std::io::Read).
        |                                       ----------  ^^^^^^^^^^^^^ explicit target is redundant
        |                                       |
        |                                       because label contains path that resolves to same destination
        |
        = note: when a link's destination is not specified,
                the label is used to resolve intra-doc links
        = note: `-D rustdoc::redundant-explicit-links` implied by `-D warnings`
        = help: to override `-D warnings` add `#[allow(rustdoc::redundant_explicit_links)]`
    help: remove explicit link target
        |
    218 | /// Loads environment variables from [`io::Read`].
        |                                      ~~~~~~~~~~~~

    error: redundant explicit link target

This can be seen in <https://github.com/allan2/dotenvy/actions/runs/6670434445/job/18130274835>, for example.

All instances of this redundant link target are fixed so that the documentation job should pass again.