### PR TITLE
Updated path not found error to be a bit more descriptive.

### DIFF
--- a/dotenv/src/find.rs
+++ b/dotenv/src/find.rs
@@ -51,7 +51,7 @@ pub fn find(directory: &Path, filename: &Path) -> Result<PathBuf> {
     } else {
         Err(Error::Io(io::Error::new(
             io::ErrorKind::NotFound,
-            ".env file not found inside parent",
+            "dotenv file not found in parent directory",
         )))
     }
 }

--- a/dotenv/src/find.rs
+++ b/dotenv/src/find.rs
@@ -51,7 +51,7 @@ pub fn find(directory: &Path, filename: &Path) -> Result<PathBuf> {
     } else {
         Err(Error::Io(io::Error::new(
             io::ErrorKind::NotFound,
-            "path not found",
+            ".env file not found inside parent",
         )))
     }
 }


### PR DESCRIPTION
Simply changes "path not found" to something slightly more descriptive, anything would work here.

I ran into the issues today while deploying a docker container just receiving the error: 
```
Error: path not found

Caused by:
    path not found
````

Often dotenvy is being loaded at the beginning of projects, and this error isn't super descriptive, I took (far too long) realizing what path was not being found, as I wasn't copying over my .env to my runtime environment.

I think a change like this could help avoid any silly mistakes for others in the future, but if not no problem, just a suggestion!