### PR TITLE
Rename `dotenv` to `load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-- MSRV updated to 1.68.0
-
 ### Changed
 
-- MSRV updated to 1.64.0
+- `dotenv` renamed to `load`
+- `dotenv_override` renamed to `load_override`
+- `dotenv` and `dotenv_override` still remain, displaying a deprecation notice
+- MSRV updated to 1.68.0
 
 ## [0.15.7] - 2023-03-22
 

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -23,12 +23,10 @@ This library loads environment variables from a _.env_ file. This is convenient 
 ### Loading at runtime
 
 ```rs
-use dotenvy::dotenv;
 use std::env;
 
 fn main() {
-    // load environment variables from .env file
-    load().expect(".env file not found");
+    dotenvy::load().expect(".env file not found");
 
     for (key, value) in env::vars() {
         println!("{key}: {value}");

--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -28,7 +28,7 @@ use std::env;
 
 fn main() {
     // load environment variables from .env file
-    dotenv().expect(".env file not found");
+    load().expect(".env file not found");
 
     for (key, value) in env::vars() {
         println!("{key}: {value}");
@@ -56,7 +56,7 @@ This fork intends to serve as the development home for the dotenv implementation
 ## What are the differences from the original?
 
 This repo fixes:
-
+- the primary function is `dotenvy::load` rather than `dotenv::dotenv`
 - home directory works correctly (no longer using the deprecated `std::env::home_dir`)
 - more helpful errors for `dotenv!` ([dotenv-rs/dotenv #57](https://github.com/dotenv-rs/dotenv/pull/57))
 

--- a/dotenv/examples/list_variables.rs
+++ b/dotenv/examples/list_variables.rs
@@ -1,7 +1,7 @@
 use dotenvy::{dotenv_iter, Error};
 
 fn main() -> Result<(), Error> {
-    dotenvy::dotenv()?;
+    dotenvy::load()?;
     for item in dotenv_iter()? {
         let (key, val) = item?;
         println!("{key}={val}");

--- a/dotenv/src/bin/dotenvy.rs
+++ b/dotenv/src/bin/dotenvy.rs
@@ -37,7 +37,7 @@ fn main() {
         .get_matches();
 
     match matches.get_one::<String>("FILE") {
-        None => dotenvy::dotenv(),
+        None => dotenvy::load(),
         Some(file) => dotenvy::from_filename(file),
     }
     .unwrap_or_else(|e| die!("error: failed to load environment: {}", e));

--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -42,7 +42,7 @@ static START: Once = Once::new();
 /// ```
 pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String> {
     START.call_once(|| {
-        dotenv().ok();
+        load().ok();
     });
     env::var(key).map_err(Error::EnvVar)
 }
@@ -59,7 +59,7 @@ pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String> {
 /// ```
 pub fn vars() -> Vars {
     START.call_once(|| {
-        dotenv().ok();
+        load().ok();
     });
     env::vars()
 }
@@ -323,10 +323,17 @@ pub fn from_read_iter<R: io::Read>(reader: R) -> Iter<R> {
 ///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// dotenvy::dotenv()?;
+/// dotenvy::load()?;
 /// #     Ok(())
 /// # }
 /// ```
+pub fn load() -> Result<PathBuf> {
+    let (path, iter) = Finder::new().find()?;
+    iter.load()?;
+    Ok(path)
+}
+
+#[deprecated(since = "0.16.0", note = "Use `load` instead")]
 pub fn dotenv() -> Result<PathBuf> {
     let (path, iter) = Finder::new().find()?;
     iter.load()?;
@@ -341,7 +348,7 @@ pub fn dotenv() -> Result<PathBuf> {
 ///
 /// If you want the existing environment to take precedence,
 /// or if you want to be able to override environment variables on the command line,
-/// then use [`dotenv`] instead.
+/// then use [`load`] instead.
 ///
 /// # Examples
 /// ```

--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -353,13 +353,20 @@ pub fn dotenv() -> Result<PathBuf> {
 /// # Examples
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// dotenvy::dotenv_override()?;
+/// dotenvy::load_override()?;
 /// #     Ok(())
 /// # }
 /// ```
-pub fn dotenv_override() -> Result<PathBuf> {
+pub fn load_override() -> Result<PathBuf> {
     let (path, iter) = Finder::new().find()?;
     iter.load_override()?;
+    Ok(path)
+}
+
+#[deprecated(since = "0.16.0", note = "Use `load_override` instead")]
+pub fn dotenv_override() -> Result<PathBuf> {
+    let (path, iter) = Finder::new().find()?;
+    iter.load()?;
     Ok(path)
 }
 

--- a/dotenv/tests/test-child-dir.rs
+++ b/dotenv/tests/test-child-dir.rs
@@ -11,7 +11,7 @@ fn test_child_dir() -> Result<(), Box<dyn error::Error>> {
 
     env::set_current_dir("child")?;
 
-    dotenvy::dotenv()?;
+    dotenvy::load()?;
     assert_eq!(env::var("TESTKEY")?, "test_val");
 
     env::set_current_dir(dir.path().parent().unwrap())?;

--- a/dotenv/tests/test-default-location-override.rs
+++ b/dotenv/tests/test-default-location-override.rs
@@ -7,7 +7,7 @@ use std::{env, error};
 fn test_default_location_override() -> Result<(), Box<dyn error::Error>> {
     let dir = make_test_dotenv()?;
 
-    dotenvy::dotenv_override()?;
+    dotenvy::load_override()?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val_overridden");
     assert_eq!(env::var("EXISTING")?, "from_file");

--- a/dotenv/tests/test-default-location.rs
+++ b/dotenv/tests/test-default-location.rs
@@ -7,7 +7,7 @@ use std::{env, error};
 fn test_default_location() -> Result<(), Box<dyn error::Error>> {
     let dir = make_test_dotenv()?;
 
-    dotenvy::dotenv()?;
+    dotenvy::load()?;
 
     assert_eq!(env::var("TESTKEY")?, "test_val");
     assert_eq!(env::var("EXISTING")?, "from_env");

--- a/dotenv/tests/test-multiline-comment.rs
+++ b/dotenv/tests/test-multiline-comment.rs
@@ -26,7 +26,7 @@ Line 6
     )
     .expect("should write test env");
 
-    dotenvy::dotenv().expect("should succeed");
+    dotenvy::load().expect("should succeed");
     assert_eq!(
         env::var("TESTKEY1").expect("testkey1 env key not set"),
         "test_val"

--- a/dotenv/tests/test-multiline.rs
+++ b/dotenv/tests/test-multiline.rs
@@ -22,7 +22,7 @@ STRONG='{}'
         value, value
     ))?;
 
-    dotenvy::dotenv()?;
+    dotenvy::load()?;
     assert_eq!(env::var("KEY")?, r#"my cool value"#);
     assert_eq!(
         env::var("KEY3")?,

--- a/dotenv/tests/test-variable-substitution.rs
+++ b/dotenv/tests/test-variable-substitution.rs
@@ -25,7 +25,7 @@ SUBSTITUTION_WITHOUT_QUOTES={}
         common_string, common_string, common_string
     ))?;
 
-    dotenvy::dotenv()?;
+    dotenvy::load()?;
 
     assert_eq!(env::var("KEY")?, "value");
     assert_eq!(env::var("KEY1")?, "value1");

--- a/dotenv_codegen/src/lib.rs
+++ b/dotenv_codegen/src/lib.rs
@@ -10,7 +10,7 @@ pub fn dotenv(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 fn dotenv_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    if let Err(err) = dotenvy::dotenv() {
+    if let Err(err) = dotenvy::load() {
         let msg = format!("Error loading .env file: {}", err);
         return quote! {
             compile_error!(#msg);

--- a/examples/dev-prod/src/main.rs
+++ b/examples/dev-prod/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     println!("Running in {app_env} mode");
 
     if app_env == AppEnv::Dev {
-        match dotenvy::dotenv() {
+        match dotenvy::load() {
             Ok(path) => println!(".env read successfully from {}", path.display()),
             Err(e) => println!("Could not load .env file: {e}"),
         };


### PR DESCRIPTION
This PR renames the primary function that loads the dotenv file to `load`.
`dotenv` is still around with a deprecation warning.

The renaming is discussed in #39.

This renaming follows the naming convention in [Ruby](https://github.com/bkeepers/dotenv) and [Go](https://github.com/joho/godotenv) implementations, which use `Dotenv.load` and `godotenv.Load` respectively.