### PR TITLE
feat: simplified `dotenv!` usage and added `dotenv_override!` macro

### DIFF
--- a/dotenv/README.md
+++ b/dotenv/README.md
@@ -40,6 +40,17 @@ fn main() {
 
 The `dotenv!` macro provided by `dotenvy_macro` crate can be used.
 
+```rs
+use dotenvy_macro::dotenv;
+
+fn main() {
+    // load environment variables from .env file
+    dotenvy_macro::dotenv!();
+
+    env!("PATH");
+}
+```
+
 ## Minimum supported Rust version
 
 Currently: **1.68.0**

--- a/dotenv_codegen/src/lib.rs
+++ b/dotenv_codegen/src/lib.rs
@@ -1,65 +1,29 @@
 #![forbid(unsafe_code)]
 
 use quote::quote;
-use std::env::{self, VarError};
-use syn::{parse::Parser, punctuated::Punctuated, spanned::Spanned, Token};
 
 #[proc_macro]
-pub fn dotenv(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    dotenv_inner(input.into()).into()
-}
-
-fn dotenv_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+pub fn dotenv(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     if let Err(err) = dotenvy::dotenv() {
         let msg = format!("Error loading .env file: {}", err);
         return quote! {
             compile_error!(#msg);
-        };
+        }
+        .into();
     }
 
-    match expand_env(input) {
-        Ok(stream) => stream,
-        Err(e) => e.to_compile_error(),
-    }
+    quote! {}.into()
 }
 
-fn expand_env(input_raw: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
-    let args = <Punctuated<syn::LitStr, Token![,]>>::parse_terminated
-        .parse(input_raw.into())
-        .expect("expected macro to be called with a comma-separated list of string literals");
-
-    let mut iter = args.iter();
-
-    let var_name = iter
-        .next()
-        .ok_or_else(|| syn::Error::new(args.span(), "dotenv! takes 1 or 2 arguments"))?
-        .value();
-    let err_msg = iter.next();
-
-    if iter.next().is_some() {
-        return Err(syn::Error::new(
-            args.span(),
-            "dotenv! takes 1 or 2 arguments",
-        ));
+#[proc_macro]
+pub fn dotenv_override(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    if let Err(err) = dotenvy::dotenv_override() {
+        let msg = format!("Error loading .env file: {}", err);
+        return quote! {
+            compile_error!(#msg);
+        }
+        .into();
     }
 
-    match env::var(&var_name) {
-        Ok(val) => Ok(quote!(#val)),
-        Err(e) => Err(syn::Error::new(
-            var_name.span(),
-            err_msg.map_or_else(
-                || match e {
-                    VarError::NotPresent => {
-                        format!("environment variable `{}` not defined", var_name)
-                    }
-
-                    VarError::NotUnicode(s) => format!(
-                        "environment variable `{}` was not valid unicode: {:?}",
-                        var_name, s
-                    ),
-                },
-                |lit| lit.value(),
-            ),
-        )),
-    }
+    quote! {}.into()
 }

--- a/dotenv_codegen/tests/basic_dotenv_macro.rs
+++ b/dotenv_codegen/tests/basic_dotenv_macro.rs
@@ -1,16 +1,5 @@
 #[test]
 fn dotenv_works() {
-    assert_eq!(dotenvy_macro::dotenv!("CODEGEN_TEST_VAR1"), "hello!");
-}
-
-#[test]
-fn two_argument_form_works() {
-    assert_eq!(
-        dotenvy_macro::dotenv!(
-            "CODEGEN_TEST_VAR2",
-            "err, you should be running this in the 'dotenv_codegen' \
-             directory to pick up the right .env file."
-        ),
-        "'quotes within quotes'"
-    );
+    dotenvy_macro::dotenv!();
+    assert_eq!(env!("CODEGEN_TEST_VAR1"), "hello!");
 }


### PR DESCRIPTION
The `dotenvy_macro::dotenv!` macro only needs to populate the variables once and then the variables are accessible via Rust's `env!` macro. This is much more natural, readable, and understandable. With the current implementation, the macro also reads the `.env` file and populates the variables then tries to come to a resolution **on each call**.

This PR also adds the `dotenv_override!` macro in line with the main library.
