### PR TITLE
Add CI check script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ merged.
 
 If you are modifying the code, make sure all tests pass. If you are adding new functionality, please add related tests.
 
-### Discuss and update
+### Discuss and update 
 
 If you receive feedback on your PR, please don't be discouraged. It's just part of the process to ensure that changes to the project are correct and necessary.
 
@@ -69,6 +69,8 @@ Please ensure that your PR passes the CI checks:
 - formatted with [Rustfmt](https://github.com/rust-lang/rustfmt)
 - [Rustdoc](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html)
   links work
+
+If you are on a *nix system, you can use the [`scripts/cicheck.sh`](scripts/cicheck.sh) script to quickly check if you pass the CI checks.
 
 #### Add an entry to the changelog
 

--- a/dotenv/src/bin/dotenvy.rs
+++ b/dotenv/src/bin/dotenvy.rs
@@ -19,7 +19,7 @@ fn make_command(name: &str, args: Vec<&str>) -> process::Command {
         command.arg(arg);
     }
 
-    return command;
+    command
 }
 
 fn main() {

--- a/scripts/cicheck.sh
+++ b/scripts/cicheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -e
+
+MSRV="1.68.0"
+
+echo "fmt check"
+cargo fmt --all --check
+
+echo "clippy"
+cargo clippy -q --all-features --all-targets --workspace -- -D warnings
+
+echo "build docs"
+RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo doc -q --no-deps --all-features --document-private-items
+
+echo "build tests"
+cargo test -q --no-run
+
+echo "running tests..."
+cargo test -q > /dev/null
+
+echo "build tests on msrv"
+RUSTUP_TOOLCHAIN="$MSRV" cargo test -q --no-run 
+
+echo "running tests on msrv..."
+RUSTUP_TOOLCHAIN="$MSRV" cargo test -q > /dev/null
+
+echo ">>>>>> ALL OK <<<<<<<<"


### PR DESCRIPTION
This adds a shell script to quickly run the same checks as the GitHub workflow. This should make it easier for people to contribute.

In the future we can add a script for windows.