### PR TITLE
Added support for JSON env variables through the "json" feature. Issue #84

### DIFF
--- a/dotenvy/Cargo.toml
+++ b/dotenvy/Cargo.toml
@@ -28,11 +28,13 @@ required-features = ["cli"]
 [dependencies]
 clap = { version = "4.5.16", features = ["derive"], optional = true }
 dotenvy-macros = { path = "../dotenvy-macros", optional = true }
+serde_json = { version = "1.0.80", optional = true }
 
 [dev-dependencies]
 temp-env = "0.3.6"
 
 [features]
 default = []
+json = ["dep:serde_json"]
 cli = ["dep:clap"]
 macros = ["dep:dotenvy-macros"]


### PR DESCRIPTION
**Description:**
Using the "json" feature the code will validate if the environment variables are a valid JSON string using serde_json when the input starts with '{' and ends with '}'. Additionally, one test has been added to ensure that this validation works correctly with JSON variables and other types of environment variables in the same file.

**Related Issue:**
Closes #84 