### PR TITLE
feat: Add substitution flag to EnvLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `EnvLoader::substitution` to enable or disable variable substitution ([PR #167](https://github.com/allan2/dotenvy/pull/167)) by [entangle2giraffe](https://github.com/entangle2giraffe)
+
 ### Changed
 - update to 2021 edition
 - update MSRV to 1.74.0

--- a/dotenvy/src/iter.rs
+++ b/dotenvy/src/iter.rs
@@ -8,6 +8,7 @@ use std::{
 pub struct Iter<B> {
     lines: Lines<B>,
     substitution_data: HashMap<String, Option<String>>,
+    substitution: bool,
 }
 
 impl<B: BufRead> Iter<B> {
@@ -15,7 +16,14 @@ impl<B: BufRead> Iter<B> {
         Self {
             lines: Lines(buf),
             substitution_data: HashMap::new(),
+            substitution: true,
         }
+    }
+
+    /// Sets whether variable substitution is performed on values.
+    pub const fn substitution(mut self, substitution: bool) -> Self {
+        self.substitution = substitution;
+        self
     }
 
     fn internal_load<F>(mut self, mut load_fn: F) -> Result<EnvMap, ParseBufError>
@@ -189,7 +197,7 @@ impl<B: BufRead> Iterator for Iter<B> {
                 None => return None,
             };
 
-            match parse::parse_line(&line, &mut self.substitution_data) {
+            match parse::parse_line(&line, &mut self.substitution_data, self.substitution) {
                 Ok(Some(res)) => return Some(Ok(res)),
                 Ok(None) => {}
                 Err(e) => return Some(Err(e)),

--- a/dotenvy/src/lib.rs
+++ b/dotenvy/src/lib.rs
@@ -124,11 +124,22 @@ pub enum EnvSequence {
     InputThenEnv,
 }
 
-#[derive(Default)]
 pub struct EnvLoader<'a> {
     path: Option<PathBuf>,
     reader: Option<Box<dyn Read + 'a>>,
     sequence: EnvSequence,
+    substitution: bool,
+}
+
+impl Default for EnvLoader<'_> {
+    fn default() -> Self {
+        Self {
+            path: None,
+            reader: None,
+            sequence: EnvSequence::default(),
+            substitution: true,
+        }
+    }
 }
 
 impl<'a> EnvLoader<'a> {
@@ -176,6 +187,15 @@ impl<'a> EnvLoader<'a> {
         self
     }
 
+    /// Sets whether variable substitution is performed on values, e.g. `$KEY` and `${KEY}`.
+    ///
+    /// Defaults to `true`. When disabled, `$` is treated as a literal character.
+    #[must_use]
+    pub const fn substitution(mut self, substitution: bool) -> Self {
+        self.substitution = substitution;
+        self
+    }
+
     fn buf(self) -> Result<BufReader<Box<dyn Read + 'a>>, crate::Error> {
         let rdr = if let Some(rdr) = self.reader {
             rdr
@@ -191,20 +211,23 @@ impl<'a> EnvLoader<'a> {
 
     fn load_input(self) -> Result<EnvMap, crate::Error> {
         let path = self.path.clone();
-        let iter = Iter::new(self.buf()?);
-        iter.load().map_err(|e| ((e, path).into()))
+        let substitution = self.substitution;
+        let iter = Iter::new(self.buf()?).substitution(substitution);
+        iter.load().map_err(|e| (e, path).into())
     }
 
     unsafe fn load_input_and_modify(self) -> Result<EnvMap, crate::Error> {
         let path = self.path.clone();
-        let iter = Iter::new(self.buf()?);
-        unsafe { iter.load_and_modify() }.map_err(|e| ((e, path).into()))
+        let substitution = self.substitution;
+        let iter = Iter::new(self.buf()?).substitution(substitution);
+        unsafe { iter.load_and_modify() }.map_err(|e| (e, path).into())
     }
 
     unsafe fn load_input_and_modify_override(self) -> Result<EnvMap, crate::Error> {
         let path = self.path.clone();
-        let iter = Iter::new(self.buf()?);
-        unsafe { iter.load_and_modify_override() }.map_err(|e| ((e, path).into()))
+        let substitution = self.substitution;
+        let iter = Iter::new(self.buf()?).substitution(substitution);
+        unsafe { iter.load_and_modify_override() }.map_err(|e| (e, path).into())
     }
 
     /// Loads environment variables into a hash map.
@@ -283,7 +306,7 @@ mod tests {
             r#"
     KEY1=new_value1
     KEY_U=$KEY+valueU
-    
+
     STRONG_QUOTES='{common_string}'
     WEAK_QUOTES="{common_string}"
     NO_QUOTES={common_string}
@@ -323,6 +346,38 @@ mod tests {
             ]
             .join(">>")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_substitution_disabled() -> Result<(), crate::Error> {
+        unsafe {
+            env::set_var("SUB_KEY", "value");
+        }
+
+        let s = r#"
+    PASSWORD=pa$$word
+    HASH='$2b$10$abcdefghijklmnopqrstuv'
+    WEAK="$SUB_KEY and ${SUB_KEY}"
+    NO_QUOTES=$SUB_KEY
+    ESCAPED="\$SUB_KEY"
+    SPECIAL_STRONG='"!@#$%^&*()_+-=[]{}|;:",.<>/?'
+    SPECIAL_WEAK="\"!@#$%^&*()_+-=[]{}|;:\",.<>/?"
+    "#;
+
+        let env_map = EnvLoader::with_reader(Cursor::new(s))
+            .sequence(EnvSequence::InputOnly)
+            .substitution(false)
+            .load()?;
+
+        let special = r#""!@#$%^&*()_+-=[]{}|;:",.<>/?"#;
+        assert_eq!(env_map.var("PASSWORD")?, "pa$$word");
+        assert_eq!(env_map.var("HASH")?, "$2b$10$abcdefghijklmnopqrstuv");
+        assert_eq!(env_map.var("WEAK")?, "$SUB_KEY and ${SUB_KEY}");
+        assert_eq!(env_map.var("NO_QUOTES")?, "$SUB_KEY");
+        assert_eq!(env_map.var("ESCAPED")?, "$SUB_KEY");
+        assert_eq!(env_map.var("SPECIAL_STRONG")?, special);
+        assert_eq!(env_map.var("SPECIAL_WEAK")?, special);
         Ok(())
     }
 

--- a/dotenvy/src/parse.rs
+++ b/dotenvy/src/parse.rs
@@ -7,23 +7,30 @@ use crate::iter::ParseBufError;
 pub fn parse_line(
     line: &str,
     substitution_data: &mut HashMap<String, Option<String>>,
+    substitution: bool,
 ) -> Result<Option<(String, String)>, ParseBufError> {
-    let mut parser = LineParser::new(line, substitution_data);
+    let mut parser = LineParser::new(line, substitution_data, substitution);
     parser.parse_line()
 }
 
 struct LineParser<'a> {
     original_line: &'a str,
     substitution_data: &'a mut HashMap<String, Option<String>>,
+    substitution: bool,
     line: &'a str,
     pos: usize,
 }
 
 impl<'a> LineParser<'a> {
-    fn new(line: &'a str, substitution_data: &'a mut HashMap<String, Option<String>>) -> Self {
+    fn new(
+        line: &'a str,
+        substitution_data: &'a mut HashMap<String, Option<String>>,
+        substitution: bool,
+    ) -> Self {
         LineParser {
             original_line: line,
             substitution_data,
+            substitution,
             line: line.trim_end(), // we don’t want trailing whitespace
             pos: 0,
         }
@@ -61,7 +68,7 @@ impl<'a> LineParser<'a> {
             return Ok(Some((key, String::new())));
         }
 
-        let parsed_value = parse_value(self.line, self.substitution_data)?;
+        let parsed_value = parse_value(self.line, self.substitution_data, self.substitution)?;
         self.substitution_data
             .insert(key.clone(), Some(parsed_value.clone()));
 
@@ -118,6 +125,7 @@ enum SubstitutionMode {
 fn parse_value(
     input: &str,
     substitution_data: &HashMap<String, Option<String>>,
+    substitution: bool,
 ) -> Result<String, ParseBufError> {
     let mut strong_quote = false; // '
     let mut weak_quote = false; // "
@@ -203,7 +211,7 @@ fn parse_value(
                     }
                 }
             }
-        } else if c == '$' {
+        } else if substitution && c == '$' {
             substitution_mode = if !strong_quote && !escaped {
                 SubstitutionMode::Block
             } else {


### PR DESCRIPTION
Adds a builder option to disable variable substitution, as requested in issue #113.

## Example

```rust
let env_map = EnvLoader::new().substitution(false).load()?;
```

## Notes
- Clippy on current stable (1.97) fails on `main` due to three pre-existing
  pedantic lints (`err.rs:64`, `parse.rs:275`, `parse.rs:577`) unrelated to
  this change. Happy to fix in a separate PR.